### PR TITLE
Allow the native pointer to be stolen

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ NativeMemoryArray
 ===
 [![GitHub Actions](https://github.com/Cysharp/NativeMemoryArray/workflows/Build-Debug/badge.svg)](https://github.com/Cysharp/NativeMemoryArray/actions) [![Releases](https://img.shields.io/github/release/Cysharp/NativeMemoryArray.svg)](https://github.com/Cysharp/NativeMemoryArray/releases)
 
-NativeMemoryArray is a native-memory backed array for .NET and Unity. The array size of C# is limited to maximum index of 0x7FFFFFC7(2,147,483,591), [Array.MaxLength](https://docs.microsoft.com/en-us/dotnet/api/system.array.maxlength). In terms of `bytes[]`, it is about 2GB. This is very cheep in the modern world. We handle the 4K/8K videos, large data set of deep-learning, huge 3D scan data of point cloud, etc.
+NativeMemoryArray is a native-memory backed array for .NET and Unity. The array size of C# is limited to maximum index of 0x7FFFFFC7(2,147,483,591), [Array.MaxLength](https://docs.microsoft.com/en-us/dotnet/api/system.array.maxlength). In terms of `bytes[]`, it is about 2GB. This is very cheap in the modern world. We handle the 4K/8K videos, large data set of deep-learning, huge 3D scan data of point cloud, etc.
 
 `NativeMemoryArray<T>` provides the native-memory backed array, it supports **infinity** length, `Span<T>` and `Memory<T>` slices, `IBufferWriter<T>`, `ReadOnlySeqeunce<T>` and .NET 6's new Scatter/Gather I/O API.
 
@@ -82,6 +82,7 @@ All `NativeMemoryArray<T>` APIs are as follows
 * `long Length`
 * `ref T this[long index]`
 * `ref T GetPinnableReference()`
+* `byte* StealPointer()`
 * `Span<T> AsSpan()`
 * `Span<T> AsSpan(long start)`
 * `Span<T> AsSpan(long start, int length)`
@@ -155,7 +156,7 @@ You can install via UPM git URL package or asset package(NativeMemoryArray.*.uni
 
 NativeMemoryArray requires `System.Memory.dll`, `System.Buffer.dll`, `System.Runtime.CompilerServices.Unsafe.dll`. It is not included in git URL so you need get from others or install via .unitypackage only once.
 
-The difference between `NativeArray<T>` and `NativeArray<T>` in Unity is that `NativeArray<T>` is a container for efficient interaction with the Unity Engine(C++) side. `NativeMemoryArray<T>` has a different role because it is for C# side only.
+The difference between `NativeArray<T>` and `NativeMemoryArray<T>` in Unity is that `NativeArray<T>` is a container for efficient interaction with the Unity Engine(C++) side. `NativeMemoryArray<T>` has a different role because it is for C# side only.
 
 License
 ---

--- a/src/NativeMemoryArray/NativeMemoryArray.cs
+++ b/src/NativeMemoryArray/NativeMemoryArray.cs
@@ -20,6 +20,7 @@ namespace Cysharp.Collections
         readonly bool addMemoryPressure;
         internal readonly byte* buffer;
         bool isDisposed;
+        bool isStolen;
 
         public long Length => length;
 
@@ -170,6 +171,12 @@ namespace Cysharp.Collections
             return ref this[0];
         }
 
+        public byte* StealPointer()
+        {
+            isStolen = true;
+            return buffer;
+        }
+
         public bool TryGetFullSpan(out Span<T> span)
         {
             if (length < int.MaxValue)
@@ -275,7 +282,7 @@ namespace Cysharp.Collections
 
         void DisposeCore()
         {
-            if (!isDisposed)
+            if (!isDisposed && !isStolen)
             {
                 isDisposed = true;
 #if UNITY_2019_1_OR_NEWER


### PR DESCRIPTION
That is, the NativeMemoryArray is no longer the "owner" of the pointer and it is now the responsibility of the caller to free the memory.

Real life example:
```csharp
public unsafe int LoadFromBuffer(NativeMemoryArray<byte> buffer, string schema = "main") =>
    SQLitePCL.raw.sqlite3_deserialize(
        SqliteConnection.Handle,
        schema,
        (nint)buffer.StealPointer(),
        buffer.Length,
        buffer.Length,
        raw.SQLITE_DESERIALIZE_FREEONCLOSE | raw.SQLITE_DESERIALIZE_RESIZEABLE);
 ```